### PR TITLE
fix: cleaner publish code, removal of unecessary file + minify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2427,15 +2427,15 @@
     },
     "packages/atoms/accordion": {
       "name": "@pap-it/accordion",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2446,17 +2446,17 @@
     },
     "packages/atoms/badge": {
       "name": "@pap-it/badge",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2467,18 +2467,18 @@
     },
     "packages/atoms/button": {
       "name": "@pap-it/button",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-form-element": "1.0.11",
-        "@pap-it/templates-prefix-suffix": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-form-element": "1.0.12",
+        "@pap-it/templates-prefix-suffix": "1.0.12"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2489,16 +2489,16 @@
     },
     "packages/atoms/checkbox": {
       "name": "@pap-it/checkbox",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-field": "1.0.11"
+        "@pap-it/templates-field": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2509,15 +2509,15 @@
     },
     "packages/atoms/divider": {
       "name": "@pap-it/divider",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-showcase": "1.0.11",
+        "@pap-it/system-showcase": "1.0.12",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2531,16 +2531,16 @@
       "version": "1.0.8",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-popover": "1.0.12",
-        "@pap-it/tools-translator": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-popover": "1.0.13",
+        "@pap-it/tools-translator": "1.0.12"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2551,17 +2551,17 @@
     },
     "packages/atoms/editor": {
       "name": "@pap-it/editor",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-showcase": "1.0.11",
+        "@pap-it/system-showcase": "1.0.12",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2572,17 +2572,17 @@
     },
     "packages/atoms/firework": {
       "name": "@pap-it/firework",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-canvas": "1.0.11",
-        "@pap-it/tools-canvas": "^0.0.0"
+        "@pap-it/templates-canvas": "1.0.12",
+        "@pap-it/tools-canvas": "0.0.1"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2592,25 +2592,25 @@
     },
     "packages/atoms/form": {
       "name": "@pap-it/form",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/accordion": "1.0.11",
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/accordion": "1.0.12",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/checkbox": "1.0.11",
-        "@pap-it/input": "1.0.11",
-        "@pap-it/switch": "1.0.12",
-        "@pap-it/system-doc": "1.0.16",
-        "@pap-it/textarea": "1.0.12",
+        "@pap-it/checkbox": "1.0.12",
+        "@pap-it/input": "1.0.12",
+        "@pap-it/switch": "1.0.13",
+        "@pap-it/system-doc": "1.0.17",
+        "@pap-it/textarea": "1.0.13",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2638,15 +2638,15 @@
     },
     "packages/atoms/icon": {
       "name": "@pap-it/icon",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-asset": "1.0.11"
+        "@pap-it/templates-asset": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2656,16 +2656,16 @@
     },
     "packages/atoms/input": {
       "name": "@pap-it/input",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-field": "1.0.11"
+        "@pap-it/templates-field": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2675,18 +2675,18 @@
     },
     "packages/atoms/menu": {
       "name": "@pap-it/menu",
-      "version": "1.0.15",
+      "version": "1.0.16",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-menu": "0.0.11"
+        "@pap-it/templates-menu": "0.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2697,15 +2697,15 @@
     },
     "packages/atoms/popup": {
       "name": "@pap-it/popup",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2716,18 +2716,18 @@
     },
     "packages/atoms/select": {
       "name": "@pap-it/select",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-field": "1.0.11",
-        "@pap-it/templates-menu": "0.0.11",
-        "@pap-it/templates-popover": "1.0.12"
+        "@pap-it/templates-field": "1.0.12",
+        "@pap-it/templates-menu": "0.0.12",
+        "@pap-it/templates-popover": "1.0.13"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2737,19 +2737,19 @@
     },
     "packages/atoms/switch": {
       "name": "@pap-it/switch",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-field": "1.0.11",
-        "@pap-it/templates-form-element": "1.0.11",
-        "@pap-it/templates-prefix-suffix": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-field": "1.0.12",
+        "@pap-it/templates-form-element": "1.0.12",
+        "@pap-it/templates-prefix-suffix": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2760,16 +2760,16 @@
     },
     "packages/atoms/tabs": {
       "name": "@pap-it/tabs",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-prefix-suffix": "1.0.11"
+        "@pap-it/templates-prefix-suffix": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2780,15 +2780,15 @@
     },
     "packages/atoms/textarea": {
       "name": "@pap-it/textarea",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-field": "1.0.11"
+        "@pap-it/templates-field": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2799,17 +2799,17 @@
     },
     "packages/atoms/tooltip": {
       "name": "@pap-it/tooltip",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-popover": "1.0.12"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-popover": "1.0.13"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2820,15 +2820,15 @@
     },
     "packages/atoms/typography": {
       "name": "@pap-it/typography",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2839,16 +2839,16 @@
     },
     "packages/molecules/aside": {
       "name": "@pap-it/aside",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11"
+        "@pap-it/templates-box": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2858,24 +2858,24 @@
     },
     "packages/molecules/chat": {
       "name": "@pap-it/chat",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/input": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/input": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-popover": "1.0.12",
-        "@pap-it/textarea": "1.0.12",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/tooltip": "1.0.12",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-popover": "1.0.13",
+        "@pap-it/textarea": "1.0.13",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/tooltip": "1.0.13",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2886,19 +2886,19 @@
     },
     "packages/molecules/codeblock": {
       "name": "@pap-it/codeblock",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/switch": "1.0.12",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/switch": "1.0.13",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2909,18 +2909,18 @@
     },
     "packages/molecules/drag-list": {
       "name": "@pap-it/drag-list",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11"
+        "@pap-it/templates-box": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2930,17 +2930,17 @@
     },
     "packages/molecules/language-menu": {
       "name": "@pap-it/language-menu",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/menu": "1.0.15",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/menu": "1.0.16",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tools-translator": "1.0.11"
+        "@pap-it/tools-translator": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2950,22 +2950,22 @@
     },
     "packages/molecules/pagination": {
       "name": "@pap-it/pagination",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/select": "0.0.13",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/select": "0.0.14",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.23.3",
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -2976,19 +2976,19 @@
     },
     "packages/molecules/pdf-viewer": {
       "name": "@pap-it/pdf-viewer",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -2998,18 +2998,18 @@
     },
     "packages/molecules/search": {
       "name": "@pap-it/search",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/input": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/input": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tools-translator": "1.0.11"
+        "@pap-it/tools-translator": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3019,24 +3019,24 @@
     },
     "packages/molecules/sidebar": {
       "name": "@pap-it/sidebar",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/accordion": "1.0.11",
-        "@pap-it/badge": "1.0.11",
-        "@pap-it/button": "1.0.11",
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/accordion": "1.0.12",
+        "@pap-it/badge": "1.0.12",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/sidebar-contact": "1.0.11",
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/sidebar-contact": "1.0.12",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3047,22 +3047,22 @@
     },
     "packages/molecules/sidebar-contact": {
       "name": "@pap-it/sidebar-contact",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/accordion": "1.0.11",
-        "@pap-it/button": "1.0.11",
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/accordion": "1.0.12",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3073,17 +3073,17 @@
     },
     "packages/molecules/steps": {
       "name": "@pap-it/steps",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3094,17 +3094,17 @@
     },
     "packages/molecules/theme": {
       "name": "@pap-it/theme",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/switch": "1.0.12",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/switch": "1.0.13",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3114,23 +3114,23 @@
     },
     "packages/organisms/header": {
       "name": "@pap-it/header",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/badge": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/language-menu": "0.0.12",
-        "@pap-it/menu": "1.0.15",
-        "@pap-it/switch": "1.0.12",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/badge": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/language-menu": "0.0.13",
+        "@pap-it/menu": "1.0.16",
+        "@pap-it/switch": "1.0.13",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/theme": "0.0.8",
-        "@pap-it/tools-theme": "1.0.11",
-        "@pap-it/tools-translator": "1.0.11"
+        "@pap-it/theme": "0.0.9",
+        "@pap-it/tools-theme": "1.0.12",
+        "@pap-it/tools-translator": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3141,16 +3141,16 @@
     },
     "packages/organisms/markdown": {
       "name": "@pap-it/markdown",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/codeblock": "1.0.12",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/codeblock": "1.0.13",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-asset": "1.0.11"
+        "@pap-it/templates-asset": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3161,31 +3161,31 @@
     },
     "packages/organisms/table": {
       "name": "@pap-it/table",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/accordion": "1.0.11",
-        "@pap-it/button": "1.0.11",
-        "@pap-it/checkbox": "1.0.11",
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/drag-list": "1.0.11",
-        "@pap-it/form": "1.0.11",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/input": "1.0.11",
-        "@pap-it/menu": "1.0.15",
-        "@pap-it/pagination": "1.0.17",
-        "@pap-it/search": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/accordion": "1.0.12",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/checkbox": "1.0.12",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/drag-list": "1.0.12",
+        "@pap-it/form": "1.0.12",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/input": "1.0.12",
+        "@pap-it/menu": "1.0.16",
+        "@pap-it/pagination": "1.0.18",
+        "@pap-it/search": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tabs": "1.0.11",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/textarea": "1.0.12",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/tooltip": "1.0.12",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/tabs": "1.0.12",
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/textarea": "1.0.13",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/tooltip": "1.0.13",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3195,15 +3195,15 @@
     },
     "packages/system/base": {
       "name": "@pap-it/system-base",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-showcase": "1.0.11",
-        "@pap-it/typography": "1.0.11",
+        "@pap-it/system-showcase": "1.0.12",
+        "@pap-it/typography": "1.0.12",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3214,21 +3214,21 @@
     },
     "packages/system/doc": {
       "name": "@pap-it/system-doc",
-      "version": "1.0.16",
+      "version": "1.0.17",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/button": "1.0.11",
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/header": "1.0.16",
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/markdown": "1.0.12",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
-        "@pap-it/system-showcase": "1.0.11",
+        "@pap-it/button": "1.0.12",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/header": "1.0.17",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/markdown": "1.0.13",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
+        "@pap-it/system-showcase": "1.0.12",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tabs": "1.0.11",
-        "@pap-it/templates-popover": "1.0.12",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/tabs": "1.0.12",
+        "@pap-it/templates-popover": "1.0.13",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
         "esbuild": "^0.17.18",
@@ -3241,7 +3241,7 @@
     },
     "packages/system/react": {
       "name": "@pap-it/system-react",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "ISC",
       "devDependencies": {
         "@types/react": "latest",
@@ -3255,17 +3255,17 @@
     },
     "packages/system/showcase": {
       "name": "@pap-it/system-showcase",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3279,23 +3279,23 @@
       "version": "1.0.10",
       "license": "ISC",
       "devDependencies": {
-        "@pap-it/system-showcase": "1.0.11",
-        "@pap-it/typography": "1.0.11",
+        "@pap-it/system-showcase": "1.0.12",
+        "@pap-it/typography": "1.0.12",
         "eslint": "^8.53.0",
         "typescript": "^5.0.4"
       }
     },
     "packages/templates/asset": {
       "name": "@pap-it/templates-asset",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3306,15 +3306,15 @@
     },
     "packages/templates/box": {
       "name": "@pap-it/templates-box",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3325,18 +3325,18 @@
     },
     "packages/templates/canvas": {
       "name": "@pap-it/templates-canvas",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/tools-canvas": "^0.0.0",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/tools-canvas": "0.0.1",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3346,15 +3346,15 @@
     },
     "packages/templates/color": {
       "name": "@pap-it/templates-color",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3365,20 +3365,20 @@
     },
     "packages/templates/field": {
       "name": "@pap-it/templates-field",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/icon": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/icon": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-form-element": "1.0.11",
-        "@pap-it/templates-prefix-suffix": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-form-element": "1.0.12",
+        "@pap-it/templates-prefix-suffix": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3388,15 +3388,15 @@
     },
     "packages/templates/form-element": {
       "name": "@pap-it/templates-form-element",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3406,21 +3406,21 @@
     },
     "packages/templates/menu": {
       "name": "@pap-it/templates-menu",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/divider": "1.0.11",
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/divider": "1.0.12",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-box": "1.0.11",
-        "@pap-it/templates-popover": "1.0.12",
-        "@pap-it/templates-prefix-suffix": "1.0.11",
-        "@pap-it/tools-translator": "1.0.11",
-        "@pap-it/typography": "1.0.11"
+        "@pap-it/templates-box": "1.0.12",
+        "@pap-it/templates-popover": "1.0.13",
+        "@pap-it/templates-prefix-suffix": "1.0.12",
+        "@pap-it/tools-translator": "1.0.12",
+        "@pap-it/typography": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3430,15 +3430,15 @@
     },
     "packages/templates/popover": {
       "name": "@pap-it/templates-popover",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3449,15 +3449,15 @@
     },
     "packages/templates/prefix-suffix": {
       "name": "@pap-it/templates-prefix-suffix",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3467,15 +3467,15 @@
     },
     "packages/tools/canvas": {
       "name": "@pap-it/tools-canvas",
-      "version": "0.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3485,15 +3485,15 @@
     },
     "packages/tools/routing": {
       "name": "@pap-it/tools-routing",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10",
-        "@pap-it/templates-asset": "1.0.11"
+        "@pap-it/templates-asset": "1.0.12"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "node-html-parser": "^6.1.5",
         "sass": "^1.70.0",
@@ -3503,15 +3503,15 @@
     },
     "packages/tools/theme": {
       "name": "@pap-it/tools-theme",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",
@@ -3522,16 +3522,16 @@
     },
     "packages/tools/translator": {
       "name": "@pap-it/tools-translator",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "ISC",
       "dependencies": {
-        "@pap-it/system-base": "1.0.11",
-        "@pap-it/system-react": "0.0.5",
+        "@pap-it/system-base": "1.0.12",
+        "@pap-it/system-react": "0.0.6",
         "@pap-it/system-utils": "1.0.10"
       },
       "devDependencies": {
-        "@pap-it/input": "1.0.11",
-        "@pap-it/system-doc": "1.0.16",
+        "@pap-it/input": "1.0.12",
+        "@pap-it/system-doc": "1.0.17",
         "esbuild": "^0.17.18",
         "eslint": "^8.53.0",
         "node-html-parser": "^6.1.5",

--- a/packages/atoms/accordion/.env
+++ b/packages/atoms/accordion/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-accordion
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/accordion/.scripts/build.sh
+++ b/packages/atoms/accordion/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/accordion/README.md
+++ b/packages/atoms/accordion/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/accordion/package.json
+++ b/packages/atoms/accordion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/accordion",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/accordion/tsconfig.prod.json
+++ b/packages/atoms/accordion/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/badge/.env
+++ b/packages/atoms/badge/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-badge
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/badge/.scripts/build.sh
+++ b/packages/atoms/badge/.scripts/build.sh
@@ -57,6 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
+
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
 fi
 
 # clear the console

--- a/packages/atoms/badge/README.md
+++ b/packages/atoms/badge/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/badge/package.json
+++ b/packages/atoms/badge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/badge",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/typography": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/typography": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/badge/tsconfig.prod.json
+++ b/packages/atoms/badge/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/button/.env
+++ b/packages/atoms/button/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-button
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/button/.scripts/build.sh
+++ b/packages/atoms/button/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/button/README.md
+++ b/packages/atoms/button/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/button/package.json
+++ b/packages/atoms/button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/button",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -41,14 +41,14 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-form-element": "1.0.11",
-    "@pap-it/templates-prefix-suffix": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-form-element": "1.0.12",
+    "@pap-it/templates-prefix-suffix": "1.0.12"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/button/tsconfig.prod.json
+++ b/packages/atoms/button/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/checkbox/.env
+++ b/packages/atoms/checkbox/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-checkbox
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/checkbox/.scripts/build.sh
+++ b/packages/atoms/checkbox/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/checkbox/README.md
+++ b/packages/atoms/checkbox/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/checkbox/package.json
+++ b/packages/atoms/checkbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/checkbox",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-field": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-field": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/checkbox/tsconfig.prod.json
+++ b/packages/atoms/checkbox/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/divider/.env
+++ b/packages/atoms/divider/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-divider
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/divider/.scripts/build.sh
+++ b/packages/atoms/divider/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/divider/README.md
+++ b/packages/atoms/divider/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/divider/package.json
+++ b/packages/atoms/divider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/divider",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-showcase": "1.0.11",
+    "@pap-it/system-showcase": "1.0.12",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/divider/tsconfig.prod.json
+++ b/packages/atoms/divider/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/dropdown/.scripts/build.sh
+++ b/packages/atoms/dropdown/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/dropdown/package.json
+++ b/packages/atoms/dropdown/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-popover": "1.0.12",
-    "@pap-it/tools-translator": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-popover": "1.0.13",
+    "@pap-it/tools-translator": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "@babel/eslint-parser": "^7.23.3",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",

--- a/packages/atoms/dropdown/tsconfig.prod.json
+++ b/packages/atoms/dropdown/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/editor/.env
+++ b/packages/atoms/editor/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-editor
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/editor/.scripts/build.sh
+++ b/packages/atoms/editor/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/editor/README.md
+++ b/packages/atoms/editor/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/editor/package.json
+++ b/packages/atoms/editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/editor",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-showcase": "1.0.11",
+    "@pap-it/system-showcase": "1.0.12",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/editor/tsconfig.prod.json
+++ b/packages/atoms/editor/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/firework/.env
+++ b/packages/atoms/firework/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-firework
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=npm
+REMOTEVERSION=0.0.0

--- a/packages/atoms/firework/.scripts/build.sh
+++ b/packages/atoms/firework/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/firework/README.md
+++ b/packages/atoms/firework/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: 0.0.0
+Version: Version: 0.0.1
+
 
 ## Development
 

--- a/packages/atoms/firework/package.json
+++ b/packages/atoms/firework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/firework",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-canvas": "1.0.11",
-    "@pap-it/tools-canvas": "^0.0.0"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-canvas": "1.0.12",
+    "@pap-it/tools-canvas": "0.0.1"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/firework/tsconfig.prod.json
+++ b/packages/atoms/firework/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/form/.env
+++ b/packages/atoms/form/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-form
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/form/.scripts/build.sh
+++ b/packages/atoms/form/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/form/README.md
+++ b/packages/atoms/form/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/form/package.json
+++ b/packages/atoms/form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/form",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,23 +40,23 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/accordion": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/typography": "1.0.11",
-    "@pap-it/button": "1.0.11",
+    "@pap-it/accordion": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/typography": "1.0.12",
+    "@pap-it/button": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/checkbox": "1.0.11",
-    "@pap-it/input": "1.0.11",
-    "@pap-it/textarea": "1.0.12",
-    "@pap-it/switch": "1.0.12",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/checkbox": "1.0.12",
+    "@pap-it/input": "1.0.12",
+    "@pap-it/textarea": "1.0.13",
+    "@pap-it/switch": "1.0.13",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/form/tsconfig.prod.json
+++ b/packages/atoms/form/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/icon/.env
+++ b/packages/atoms/icon/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-icon
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/icon/.scripts/build.sh
+++ b/packages/atoms/icon/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/icon/README.md
+++ b/packages/atoms/icon/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/icon/package.json
+++ b/packages/atoms/icon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/icon",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/templates-asset": "1.0.11",
+    "@pap-it/templates-asset": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/icon/tsconfig.prod.json
+++ b/packages/atoms/icon/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/input/.env
+++ b/packages/atoms/input/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-input
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/input/.scripts/build.sh
+++ b/packages/atoms/input/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/input/README.md
+++ b/packages/atoms/input/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/input/package.json
+++ b/packages/atoms/input/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/input",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/system-react": "0.0.5",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/system-react": "0.0.6",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/templates-field": "1.0.11"
+    "@pap-it/templates-field": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/input/tsconfig.prod.json
+++ b/packages/atoms/input/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/menu/.env
+++ b/packages/atoms/menu/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-menu
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.14
+REMOTEVERSION=1.0.15

--- a/packages/atoms/menu/.scripts/build.sh
+++ b/packages/atoms/menu/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/menu/README.md
+++ b/packages/atoms/menu/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version:Version: Version: 1.0.15
+Version:Version: Version: 1.0.16
+
 
 
 

--- a/packages/atoms/menu/package.json
+++ b/packages/atoms/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/menu",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-menu": "0.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-menu": "0.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/menu/tsconfig.prod.json
+++ b/packages/atoms/menu/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/popup/.env
+++ b/packages/atoms/popup/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-popup
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/popup/.scripts/build.sh
+++ b/packages/atoms/popup/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/popup/README.md
+++ b/packages/atoms/popup/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/popup/package.json
+++ b/packages/atoms/popup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/popup",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/popup/tsconfig.prod.json
+++ b/packages/atoms/popup/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/select/.env
+++ b/packages/atoms/select/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-select
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.12
+REMOTEVERSION=0.0.13

--- a/packages/atoms/select/.scripts/build.sh
+++ b/packages/atoms/select/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/select/README.md
+++ b/packages/atoms/select/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version:Version: Version: 0.0.13
+Version:Version: Version: 0.0.14
+
 
 
 

--- a/packages/atoms/select/package.json
+++ b/packages/atoms/select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/select",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-field": "1.0.11",
-    "@pap-it/templates-menu": "0.0.11",
-    "@pap-it/templates-popover": "1.0.12"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-field": "1.0.12",
+    "@pap-it/templates-menu": "0.0.12",
+    "@pap-it/templates-popover": "1.0.13"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/select/tsconfig.prod.json
+++ b/packages/atoms/select/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/switch/.env
+++ b/packages/atoms/switch/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-switch
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/atoms/switch/.scripts/build.sh
+++ b/packages/atoms/switch/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/switch/README.md
+++ b/packages/atoms/switch/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.12
+Version: Version: Version: 1.0.13
+
 
 
 

--- a/packages/atoms/switch/package.json
+++ b/packages/atoms/switch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/switch",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -41,15 +41,15 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-field": "1.0.11",
-    "@pap-it/templates-form-element": "1.0.11",
-    "@pap-it/templates-prefix-suffix": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-field": "1.0.12",
+    "@pap-it/templates-form-element": "1.0.12",
+    "@pap-it/templates-prefix-suffix": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/switch/tsconfig.prod.json
+++ b/packages/atoms/switch/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/tabs/.env
+++ b/packages/atoms/tabs/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-tabs
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/tabs/.scripts/build.sh
+++ b/packages/atoms/tabs/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/tabs/README.md
+++ b/packages/atoms/tabs/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/tabs/package.json
+++ b/packages/atoms/tabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tabs",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-prefix-suffix": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-prefix-suffix": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/tabs/tsconfig.prod.json
+++ b/packages/atoms/tabs/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/textarea/.env
+++ b/packages/atoms/textarea/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-textarea
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/atoms/textarea/.scripts/build.sh
+++ b/packages/atoms/textarea/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/textarea/README.md
+++ b/packages/atoms/textarea/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.12
+Version: Version: Version: 1.0.13
+
 
 
 

--- a/packages/atoms/textarea/package.json
+++ b/packages/atoms/textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/textarea",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -41,11 +41,11 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-field": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-field": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/textarea/tsconfig.prod.json
+++ b/packages/atoms/textarea/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/tooltip/.env
+++ b/packages/atoms/tooltip/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-tooltip
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/atoms/tooltip/.scripts/build.sh
+++ b/packages/atoms/tooltip/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/tooltip/README.md
+++ b/packages/atoms/tooltip/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version:Version: Version: 1.0.12
+Version:Version: Version: 1.0.13
+
 
 
 

--- a/packages/atoms/tooltip/package.json
+++ b/packages/atoms/tooltip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tooltip",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-popover": "1.0.12"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-popover": "1.0.13"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/atoms/tooltip/tsconfig.prod.json
+++ b/packages/atoms/tooltip/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/atoms/typography/.env
+++ b/packages/atoms/typography/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-typography
 ATOMICTYPE=atoms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/atoms/typography/.scripts/build.sh
+++ b/packages/atoms/typography/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/atoms/typography/README.md
+++ b/packages/atoms/typography/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/atoms/typography/package.json
+++ b/packages/atoms/typography/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/typography",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/atoms/typography/tsconfig.prod.json
+++ b/packages/atoms/typography/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/aside/.env
+++ b/packages/molecules/aside/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-aside
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.6
+REMOTEVERSION=0.0.7

--- a/packages/molecules/aside/.scripts/build.sh
+++ b/packages/molecules/aside/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/aside/README.md
+++ b/packages/molecules/aside/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 0.0.7
+Version: Version: Version: 0.0.8
+
 
 
 

--- a/packages/molecules/aside/package.json
+++ b/packages/molecules/aside/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/aside",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/aside/tsconfig.prod.json
+++ b/packages/molecules/aside/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/chat/.env
+++ b/packages/molecules/chat/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-chat
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.12
+REMOTEVERSION=1.0.13

--- a/packages/molecules/chat/.scripts/build.sh
+++ b/packages/molecules/chat/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/chat/README.md
+++ b/packages/molecules/chat/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version:Version: Version: 1.0.13
+Version:Version: Version: 1.0.14
+
 
 
 

--- a/packages/molecules/chat/package.json
+++ b/packages/molecules/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/chat",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,22 +40,22 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/input": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-popover": "1.0.12",
-    "@pap-it/textarea": "1.0.12",
-    "@pap-it/tools-translator": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/input": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-popover": "1.0.13",
+    "@pap-it/textarea": "1.0.13",
+    "@pap-it/tools-translator": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/typography": "1.0.11",
-    "@pap-it/tooltip": "1.0.12"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/typography": "1.0.12",
+    "@pap-it/tooltip": "1.0.13"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/chat/tsconfig.prod.json
+++ b/packages/molecules/chat/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/codeblock/.env
+++ b/packages/molecules/codeblock/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-codeblock
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/molecules/codeblock/.scripts/build.sh
+++ b/packages/molecules/codeblock/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/codeblock/README.md
+++ b/packages/molecules/codeblock/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.12
+Version: Version: Version: 1.0.13
+
 
 
 

--- a/packages/molecules/codeblock/package.json
+++ b/packages/molecules/codeblock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/codeblock",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,17 +40,17 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/switch": "1.0.12",
-    "@pap-it/typography": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/switch": "1.0.13",
+    "@pap-it/typography": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/codeblock/tsconfig.prod.json
+++ b/packages/molecules/codeblock/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/drag-list/.env
+++ b/packages/molecules/drag-list/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-drag-list
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/drag-list/.scripts/build.sh
+++ b/packages/molecules/drag-list/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/drag-list/README.md
+++ b/packages/molecules/drag-list/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/drag-list/package.json
+++ b/packages/molecules/drag-list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/drag-list",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/drag-list/tsconfig.prod.json
+++ b/packages/molecules/drag-list/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/language-menu/.env
+++ b/packages/molecules/language-menu/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-language-menu
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.11
+REMOTEVERSION=0.0.12

--- a/packages/molecules/language-menu/.scripts/build.sh
+++ b/packages/molecules/language-menu/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/language-menu/README.md
+++ b/packages/molecules/language-menu/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version:Version: Version: 0.0.12
+Version:Version: Version: 0.0.13
+
 
 
 

--- a/packages/molecules/language-menu/package.json
+++ b/packages/molecules/language-menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/language-menu",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/menu": "1.0.15",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/menu": "1.0.16",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tools-translator": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tools-translator": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/language-menu/tsconfig.prod.json
+++ b/packages/molecules/language-menu/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/pagination/.env
+++ b/packages/molecules/pagination/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-pagination
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.16
+REMOTEVERSION=1.0.17

--- a/packages/molecules/pagination/.scripts/build.sh
+++ b/packages/molecules/pagination/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/pagination/README.md
+++ b/packages/molecules/pagination/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version:Version: Version: 1.0.17
+Version:Version: Version: 1.0.18
+
 
 
 

--- a/packages/molecules/pagination/package.json
+++ b/packages/molecules/pagination/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/pagination",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,19 +40,19 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/select": "0.0.13",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/select": "0.0.14",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.23.3",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/molecules/pagination/tsconfig.prod.json
+++ b/packages/molecules/pagination/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/pdf-viewer/.env
+++ b/packages/molecules/pdf-viewer/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-pdf-viewer
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/pdf-viewer/.scripts/build.sh
+++ b/packages/molecules/pdf-viewer/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/pdf-viewer/README.md
+++ b/packages/molecules/pdf-viewer/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/pdf-viewer/package.json
+++ b/packages/molecules/pdf-viewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/pdf-viewer",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,16 +40,16 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/pdf-viewer/tsconfig.prod.json
+++ b/packages/molecules/pdf-viewer/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/search/.env
+++ b/packages/molecules/search/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-search
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/search/.scripts/build.sh
+++ b/packages/molecules/search/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/search/README.md
+++ b/packages/molecules/search/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/search/package.json
+++ b/packages/molecules/search/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/search",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/button": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/input": "1.0.11",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/input": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tools-translator": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tools-translator": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/search/tsconfig.prod.json
+++ b/packages/molecules/search/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/sidebar-contact/.env
+++ b/packages/molecules/sidebar-contact/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-sidebar-contact
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/sidebar-contact/.scripts/build.sh
+++ b/packages/molecules/sidebar-contact/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/sidebar-contact/README.md
+++ b/packages/molecules/sidebar-contact/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/sidebar-contact/package.json
+++ b/packages/molecules/sidebar-contact/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/sidebar-contact",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,20 +40,20 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/accordion": "1.0.11",
-    "@pap-it/button": "1.0.11",
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/tools-translator": "1.0.11",
+    "@pap-it/accordion": "1.0.12",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/tools-translator": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/sidebar-contact/tsconfig.prod.json
+++ b/packages/molecules/sidebar-contact/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/sidebar/.env
+++ b/packages/molecules/sidebar/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-sidebar
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/sidebar/.scripts/build.sh
+++ b/packages/molecules/sidebar/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/sidebar/README.md
+++ b/packages/molecules/sidebar/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/sidebar/package.json
+++ b/packages/molecules/sidebar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/sidebar",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,22 +40,22 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/accordion": "1.0.11",
-    "@pap-it/badge": "1.0.11",
-    "@pap-it/button": "1.0.11",
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/tools-translator": "1.0.11",
+    "@pap-it/accordion": "1.0.12",
+    "@pap-it/badge": "1.0.12",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/tools-translator": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/sidebar-contact": "1.0.11",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/sidebar-contact": "1.0.12",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/sidebar/tsconfig.prod.json
+++ b/packages/molecules/sidebar/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/steps/.env
+++ b/packages/molecules/steps/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-steps
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/molecules/steps/.scripts/build.sh
+++ b/packages/molecules/steps/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/steps/README.md
+++ b/packages/molecules/steps/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: atoms
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/molecules/steps/package.json
+++ b/packages/molecules/steps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/steps",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/typography": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/typography": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/steps/tsconfig.prod.json
+++ b/packages/molecules/steps/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/molecules/theme/.env
+++ b/packages/molecules/theme/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-theme
 ATOMICTYPE=molecules
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.7
+REMOTEVERSION=0.0.8

--- a/packages/molecules/theme/.scripts/build.sh
+++ b/packages/molecules/theme/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/molecules/theme/README.md
+++ b/packages/molecules/theme/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version: Version: Version: 0.0.8
+Version: Version: Version: 0.0.9
+
 
 
 

--- a/packages/molecules/theme/package.json
+++ b/packages/molecules/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/theme",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/switch": "1.0.12"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/switch": "1.0.13"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/molecules/theme/tsconfig.prod.json
+++ b/packages/molecules/theme/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/organisms/header/.env
+++ b/packages/organisms/header/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-header
 ATOMICTYPE=organisms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.15
+REMOTEVERSION=1.0.16

--- a/packages/organisms/header/.scripts/build.sh
+++ b/packages/organisms/header/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/organisms/header/README.md
+++ b/packages/organisms/header/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: molecules
 
-Version:Version: Version: 1.0.16
+Version:Version: Version: 1.0.17
+
 
 
 

--- a/packages/organisms/header/package.json
+++ b/packages/organisms/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/header",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,20 +40,20 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/badge": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/language-menu": "0.0.12",
-    "@pap-it/menu": "1.0.15",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/badge": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/language-menu": "0.0.13",
+    "@pap-it/menu": "1.0.16",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/theme": "0.0.8",
-    "@pap-it/switch": "1.0.12",
-    "@pap-it/tools-theme": "1.0.11",
-    "@pap-it/tools-translator": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/theme": "0.0.9",
+    "@pap-it/switch": "1.0.13",
+    "@pap-it/tools-theme": "1.0.12",
+    "@pap-it/tools-translator": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "eslint": "^8.53.0",
     "node-html-parser": "^6.1.5",

--- a/packages/organisms/header/tsconfig.prod.json
+++ b/packages/organisms/header/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/organisms/markdown/.env
+++ b/packages/organisms/markdown/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-markdown
 ATOMICTYPE=organisms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/organisms/markdown/.scripts/build.sh
+++ b/packages/organisms/markdown/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/organisms/markdown/README.md
+++ b/packages/organisms/markdown/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: organisms
 
-Version: Version: Version: 1.0.12
+Version: Version: Version: 1.0.13
+
 
 
 

--- a/packages/organisms/markdown/package.json
+++ b/packages/organisms/markdown/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/markdown",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/codeblock": "1.0.12",
-    "@pap-it/templates-asset": "1.0.11",
+    "@pap-it/codeblock": "1.0.13",
+    "@pap-it/templates-asset": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/organisms/markdown/tsconfig.prod.json
+++ b/packages/organisms/markdown/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/organisms/table/.env
+++ b/packages/organisms/table/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-table
 ATOMICTYPE=organisms
 PACKAGENAME=
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.16
+REMOTEVERSION=1.0.17

--- a/packages/organisms/table/.scripts/build.sh
+++ b/packages/organisms/table/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/organisms/table/README.md
+++ b/packages/organisms/table/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: organisms
 
-Version:Version: Version: 1.0.17
+Version:Version: Version: 1.0.18
+
 
 
 

--- a/packages/organisms/table/package.json
+++ b/packages/organisms/table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/table",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,28 +40,28 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/accordion": "1.0.11",
-    "@pap-it/button": "1.0.11",
-    "@pap-it/checkbox": "1.0.11",
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/drag-list": "1.0.11",
-    "@pap-it/form": "1.0.11",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/input": "1.0.11",
-    "@pap-it/menu": "1.0.15",
-    "@pap-it/pagination": "1.0.17",
-    "@pap-it/search": "1.0.11",
+    "@pap-it/accordion": "1.0.12",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/checkbox": "1.0.12",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/drag-list": "1.0.12",
+    "@pap-it/form": "1.0.12",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/input": "1.0.12",
+    "@pap-it/menu": "1.0.16",
+    "@pap-it/pagination": "1.0.18",
+    "@pap-it/search": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tabs": "1.0.11",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/textarea": "1.0.12",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/tooltip": "1.0.12",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tabs": "1.0.12",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/textarea": "1.0.13",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/tooltip": "1.0.13",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/organisms/table/tsconfig.prod.json
+++ b/packages/organisms/table/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/system/base/.env
+++ b/packages/system/base/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-base-system
 ATOMICTYPE=system
 PACKAGENAME=system-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/system/base/.scripts/build.sh
+++ b/packages/system/base/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/system/base/README.md
+++ b/packages/system/base/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: system
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/system/base/package.json
+++ b/packages/system/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/system-base",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -19,7 +19,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -34,12 +34,12 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-showcase": "1.0.11",
-    "@pap-it/typography": "1.0.11",
+    "@pap-it/system-showcase": "1.0.12",
+    "@pap-it/typography": "1.0.12",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/system/base/tsconfig.prod.json
+++ b/packages/system/base/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/system/doc/.env
+++ b/packages/system/doc/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-doc-system
 ATOMICTYPE=system
 PACKAGENAME=system-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.15
+REMOTEVERSION=1.0.16

--- a/packages/system/doc/README.md
+++ b/packages/system/doc/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: system
 
-Version:Version: Version: 1.0.16
+Version:Version: Version: 1.0.17
+
 
 
 

--- a/packages/system/doc/package.json
+++ b/packages/system/doc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/system-doc",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -33,18 +33,18 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/system-showcase": "1.0.11",
-    "@pap-it/button": "1.0.11",
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/header": "1.0.16",
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/markdown": "1.0.12",
-    "@pap-it/tabs": "1.0.11",
-    "@pap-it/templates-popover": "1.0.12",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/system-showcase": "1.0.12",
+    "@pap-it/button": "1.0.12",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/header": "1.0.17",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/markdown": "1.0.13",
+    "@pap-it/tabs": "1.0.12",
+    "@pap-it/templates-popover": "1.0.13",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
     "eslint": "^8.53.0",

--- a/packages/system/doc/tsconfig.prod.json
+++ b/packages/system/doc/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/system/react/.env
+++ b/packages/system/react/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-react-system
 ATOMICTYPE=system
 PACKAGENAME=system-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.4
+REMOTEVERSION=0.0.5

--- a/packages/system/react/.scripts/build.sh
+++ b/packages/system/react/.scripts/build.sh
@@ -45,7 +45,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/system/react/README.md
+++ b/packages/system/react/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: system
 
-Version: Version: 0.0.5
+Version: Version: Version: 0.0.6
+
 
 
 ## Development

--- a/packages/system/react/package.json
+++ b/packages/system/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/system-react",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "scripts": {
     "test": ".scripts/test.sh",
     "build": ".scripts/build.sh",

--- a/packages/system/react/tsconfig.prod.json
+++ b/packages/system/react/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/system/showcase/.env
+++ b/packages/system/showcase/.env
@@ -5,4 +5,4 @@ PREFIXNAME=showcase-system
 ATOMICTYPE=system
 PACKAGENAME=system-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/system/showcase/.scripts/build.sh
+++ b/packages/system/showcase/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/system/showcase/README.md
+++ b/packages/system/showcase/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: system
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/system/showcase/package.json
+++ b/packages/system/showcase/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/system-showcase",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -25,7 +25,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -39,15 +39,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/system/showcase/tsconfig.prod.json
+++ b/packages/system/showcase/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/system/utils/.scripts/build.sh
+++ b/packages/system/utils/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/system/utils/package.json
+++ b/packages/system/utils/package.json
@@ -30,8 +30,8 @@
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-showcase": "1.0.11",
-    "@pap-it/typography": "1.0.11",
+    "@pap-it/system-showcase": "1.0.12",
+    "@pap-it/typography": "1.0.12",
     "typescript": "^5.0.4"
   },
   "keywords": [

--- a/packages/system/utils/tsconfig.prod.json
+++ b/packages/system/utils/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/asset/.env
+++ b/packages/templates/asset/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-asset-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/asset/.scripts/build.sh
+++ b/packages/templates/asset/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/asset/README.md
+++ b/packages/templates/asset/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/asset/package.json
+++ b/packages/templates/asset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-asset",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -22,7 +22,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -36,13 +36,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/asset/tsconfig.prod.json
+++ b/packages/templates/asset/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/box/.env
+++ b/packages/templates/box/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-box-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/box/.scripts/build.sh
+++ b/packages/templates/box/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/box/README.md
+++ b/packages/templates/box/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/box/package.json
+++ b/packages/templates/box/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-box",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/box/tsconfig.prod.json
+++ b/packages/templates/box/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/canvas/.env
+++ b/packages/templates/canvas/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-canvas-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/canvas/.scripts/build.sh
+++ b/packages/templates/canvas/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/canvas/README.md
+++ b/packages/templates/canvas/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/canvas/package.json
+++ b/packages/templates/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-canvas",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,15 +40,15 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/tools-canvas": "^0.0.0",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/tools-canvas": "0.0.1",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/canvas/tsconfig.prod.json
+++ b/packages/templates/canvas/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/color/.env
+++ b/packages/templates/color/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-color-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/color/.scripts/build.sh
+++ b/packages/templates/color/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/color/README.md
+++ b/packages/templates/color/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/color/package.json
+++ b/packages/templates/color/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-color",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/color/tsconfig.prod.json
+++ b/packages/templates/color/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/field/.env
+++ b/packages/templates/field/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-field-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/field/.scripts/build.sh
+++ b/packages/templates/field/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/field/README.md
+++ b/packages/templates/field/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/field/package.json
+++ b/packages/templates/field/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-field",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,17 +40,17 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/icon": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/icon": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-form-element": "1.0.11",
-    "@pap-it/templates-prefix-suffix": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-form-element": "1.0.12",
+    "@pap-it/templates-prefix-suffix": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/field/tsconfig.prod.json
+++ b/packages/templates/field/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/form-element/.env
+++ b/packages/templates/form-element/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-form-element-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/form-element/.scripts/build.sh
+++ b/packages/templates/form-element/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/form-element/README.md
+++ b/packages/templates/form-element/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/form-element/package.json
+++ b/packages/templates/form-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-form-element",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -41,11 +41,11 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/system-base": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/system-base": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "tslib": "^2.5.0",
     "sass": "^1.70.0",

--- a/packages/templates/form-element/tsconfig.prod.json
+++ b/packages/templates/form-element/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/menu/.env
+++ b/packages/templates/menu/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-menu-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=0.0.10
+REMOTEVERSION=0.0.11

--- a/packages/templates/menu/.scripts/build.sh
+++ b/packages/templates/menu/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/menu/README.md
+++ b/packages/templates/menu/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version:Version: Version: 0.0.11
+Version:Version: Version: 0.0.12
+
 
 
 

--- a/packages/templates/menu/package.json
+++ b/packages/templates/menu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-menu",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -40,18 +40,18 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/divider": "1.0.11",
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/divider": "1.0.12",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-box": "1.0.11",
-    "@pap-it/templates-popover": "1.0.12",
-    "@pap-it/templates-prefix-suffix": "1.0.11",
-    "@pap-it/tools-translator": "1.0.11",
-    "@pap-it/typography": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-box": "1.0.12",
+    "@pap-it/templates-popover": "1.0.13",
+    "@pap-it/templates-prefix-suffix": "1.0.12",
+    "@pap-it/tools-translator": "1.0.12",
+    "@pap-it/typography": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/menu/tsconfig.prod.json
+++ b/packages/templates/menu/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/popover/.env
+++ b/packages/templates/popover/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-popover-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.11
+REMOTEVERSION=1.0.12

--- a/packages/templates/popover/.scripts/build.sh
+++ b/packages/templates/popover/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/popover/README.md
+++ b/packages/templates/popover/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version:Version: Version: 1.0.12
+Version:Version: Version: 1.0.13
+
 
 
 

--- a/packages/templates/popover/package.json
+++ b/packages/templates/popover/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-popover",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/popover/tsconfig.prod.json
+++ b/packages/templates/popover/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/templates/prefix-suffix/.env
+++ b/packages/templates/prefix-suffix/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-prefix-suffix-template
 ATOMICTYPE=templates
 PACKAGENAME=templates-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/templates/prefix-suffix/.scripts/build.sh
+++ b/packages/templates/prefix-suffix/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/templates/prefix-suffix/README.md
+++ b/packages/templates/prefix-suffix/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: templates
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/templates/prefix-suffix/package.json
+++ b/packages/templates/prefix-suffix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/templates-prefix-suffix",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,12 +40,12 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/templates/prefix-suffix/tsconfig.prod.json
+++ b/packages/templates/prefix-suffix/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/tools/canvas/.env
+++ b/packages/tools/canvas/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-canvas-tool
 ATOMICTYPE=tools
 PACKAGENAME=tools-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=npm
+REMOTEVERSION=0.0.0

--- a/packages/tools/canvas/.scripts/build.sh
+++ b/packages/tools/canvas/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/tools/canvas/README.md
+++ b/packages/tools/canvas/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: tools
 
-Version: 0.0.0
+Version: Version: 0.0.1
+
 
 ## Development
 

--- a/packages/tools/canvas/package.json
+++ b/packages/tools/canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tools-canvas",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "onkelhoy",
   "private": false,
@@ -41,11 +41,11 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/system-base": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/system-base": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "tslib": "^2.5.0",
     "sass": "^1.70.0",

--- a/packages/tools/canvas/tsconfig.prod.json
+++ b/packages/tools/canvas/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/tools/routing/.env
+++ b/packages/tools/routing/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-routing-tool
 ATOMICTYPE=tools
 PACKAGENAME=tools-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/tools/routing/.scripts/build.sh
+++ b/packages/tools/routing/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/tools/routing/README.md
+++ b/packages/tools/routing/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: system
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/tools/routing/package.json
+++ b/packages/tools/routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tools-routing",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -41,11 +41,11 @@
   },
   "dependencies": {
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5",
-    "@pap-it/templates-asset": "1.0.11"
+    "@pap-it/system-react": "0.0.6",
+    "@pap-it/templates-asset": "1.0.12"
   },
   "devDependencies": {
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/tools/routing/tsconfig.prod.json
+++ b/packages/tools/routing/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/tools/theme/.env
+++ b/packages/tools/theme/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-theme-tool
 ATOMICTYPE=tools
 PACKAGENAME=tools-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/tools/theme/.scripts/build.sh
+++ b/packages/tools/theme/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/tools/theme/README.md
+++ b/packages/tools/theme/README.md
@@ -2,7 +2,8 @@
 
 Atomic Type: tools
 
-Version: Version: Version: 1.0.11
+Version: Version: Version: 1.0.12
+
 
 
 

--- a/packages/tools/theme/package.json
+++ b/packages/tools/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tools-theme",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,13 +40,13 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/tools/theme/tsconfig.prod.json
+++ b/packages/tools/theme/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/packages/tools/translator/.env
+++ b/packages/tools/translator/.env
@@ -5,4 +5,4 @@ PREFIXNAME=pap-translator
 ATOMICTYPE=tools
 PACKAGENAME=tools-
 ROOTDIR=/Users/henry/Developer/projects/web-components
-REMOTEVERSION=1.0.10
+REMOTEVERSION=1.0.11

--- a/packages/tools/translator/.scripts/build.sh
+++ b/packages/tools/translator/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/packages/tools/translator/package.json
+++ b/packages/tools/translator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pap-it/tools-translator",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "init": "sh .scripts/init.sh",
     "test": ".scripts/test.sh",
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "Henry Pap",
   "private": false,
@@ -40,14 +40,14 @@
     "url": "https://github.com/onkelhoy/web-components.git"
   },
   "dependencies": {
-    "@pap-it/system-base": "1.0.11",
+    "@pap-it/system-base": "1.0.12",
     "@pap-it/system-utils": "1.0.10",
-    "@pap-it/system-react": "0.0.5"
+    "@pap-it/system-react": "0.0.6"
   },
   "devDependencies": {
     "eslint": "^8.53.0",
-    "@pap-it/input": "1.0.11",
-    "@pap-it/system-doc": "1.0.16",
+    "@pap-it/input": "1.0.12",
+    "@pap-it/system-doc": "1.0.17",
     "esbuild": "^0.17.18",
     "node-html-parser": "^6.1.5",
     "sass": "^1.70.0",

--- a/packages/tools/translator/tsconfig.prod.json
+++ b/packages/tools/translator/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/scripts/generator/template/.scripts/build.sh
+++ b/scripts/generator/template/.scripts/build.sh
@@ -57,7 +57,12 @@ if [ "$DEV" = true ]; then
   tsc
 else
   tsc -p tsconfig.prod.json
-fi
 
+  # Find all .js files in the dist directory and its subdirectories
+  find ./dist -name '*.js' -type f | while read file; do
+    # Use esbuild to minify each .js file and overwrite the original file
+    esbuild "$file" --minify --allow-overwrite --outfile="$file"
+  done
+fi
 # clear the console
 echo "files successfully built"

--- a/scripts/generator/template/package.json
+++ b/scripts/generator/template/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "GITNAME",
   "private": false,

--- a/scripts/generator/template/tsconfig.prod.json
+++ b/scripts/generator/template/tsconfig.prod.json
@@ -3,10 +3,12 @@
   "compilerOptions": {
     "sourceMap": false,
     "inlineSources": false,
-    "declarationMap": false
+    "declarationMap": false,
+    "incremental": false
   },
   "exclude": [
     "**/*.test.ts",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist/*.tsbuildinfo"
   ]
 }

--- a/scripts/project/template/scripts/generator/template/package.json
+++ b/scripts/project/template/scripts/generator/template/package.json
@@ -26,7 +26,7 @@
   "exports": {
     ".": "./dist/src/index.js",
     "./wc": "./dist/register.bundle.mjs",
-    "./react": "./dist/react/index.ts"
+    "./react": "./dist/react/index.js"
   },
   "author": "GITNAME",
   "private": false,


### PR DESCRIPTION
closes: #133
changelog:
- fix: excluding tsbuldinfo

- fix: version bump and point correct point to react index.js file

- release: dry run

- fix: minify tsc output using esbuild

- fix: allow overwrite on esbuild

- release: no dry run