### PR TITLE
fix: bug fixes + small improvements

### DIFF
--- a/packages/tools/translator/src/translator.ts
+++ b/packages/tools/translator/src/translator.ts
@@ -164,7 +164,7 @@ export function detect() {
     return navigator_lang;
   }
 }
-export function init(languages?: BasicLanguageData[]) {
+export function init(languages?: BasicLanguageData[], choosen?: string) {
   // NOTE I put or subscribe as I wish to be able to control "setURL" from outside 
   // (before init and subscribe is unlikly to be set by outside.. like extremly unlikely)
   if (!window.papLocalization || !window.papLocalization.subscribe) {
@@ -213,9 +213,13 @@ export function init(languages?: BasicLanguageData[]) {
         }
       }
     }, 1000));
+  }
 
-    if (languages) {
-      window.papLocalization.addAll(languages);
+  if (languages) {
+    window.papLocalization.addAll(languages);
+
+    if (choosen) {
+      window.papLocalization.change(choosen);
     }
   }
 }


### PR DESCRIPTION
closes: #141
changelog:
- fix: safely access translation object

- fix: useTranslation not defaulting to lang in order to allow init happening

- react: [translator hook] lang points to detect value

- release: version bump

- bug: reapply events + button tabindex

- release: version bump
- fix: translator init addAll called even if already init

- fix: translator added change option in init